### PR TITLE
Enable GitHub release publish from workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
 
   matrix:


### PR DESCRIPTION
To enable pushing binaries as part of the release requires a permission isolated to the admin-workflow