### PR TITLE
WIP: Fix Krates/cargo_metadata pairing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
  "cargo-geiger-serde",
  "cargo-platform",
  "cargo-util",
- "cargo_metadata 0.18.1",
+ "cargo_metadata",
  "colored",
  "console",
  "fs_extra",
@@ -433,20 +433,6 @@ name = "cargo_metadata"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -2043,7 +2029,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a857d4b6450fbc2b85c03684b2beae51916a5a90e2fb5f9c2b8acc920ad29e49"
 dependencies = [
- "cargo_metadata 0.15.4",
+ "cargo_metadata",
  "cfg-expr",
  "petgraph",
  "semver",

--- a/cargo-geiger/Cargo.toml
+++ b/cargo-geiger/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "experimental" }
 anyhow = "1.0.70"
 cargo = "0.75.1"
 cargo-geiger-serde = { path = "../cargo-geiger-serde", version = "0.2.3" }
-cargo_metadata = "0.18.1"
+cargo_metadata = "0.15.0"
 cargo-platform = "0.1.2"
 colored = "2.0.0"
 console = "0.15.5"


### PR DESCRIPTION
EDIT: Needs work. There are broken abstractions / couplings between krates/geiger/cargo_metadata

The only way to fix it is to upgrade the deps but that leads to a lot of breaking changes between krates / cargo_metadata which are coupled as internal abstractions that are very time consuming to eradicate and / or fix.

The biggest is cargo_metadata::PackageId is not recognised by krates anymore and the previous versions of krates have some unhandled unwrap that is deep down the parser that handles the repr (that comes from the lockfile)

The release from crates.io works fine but transient dependency messed things up for main dev which is pity.

I'll continue untangling the abstractions that are affected by the breakage in order to upgrade to fix.