### PR TITLE
Fix unused import error in integration tests

### DIFF
--- a/cargo-geiger/tests/integration_tests.rs
+++ b/cargo-geiger/tests/integration_tests.rs
@@ -8,7 +8,6 @@ use self::run::run_geiger_with;
 
 use insta::assert_snapshot;
 use rstest::rstest;
-use std::env;
 use std::process::Output;
 
 #[rstest(


### PR DESCRIPTION
```
> error: unused import: `std::env`
>   --> cargo-geiger/tests/integration_tests.rs:11:5
>    |
> 11 | use std::env;
>    |     ^^^^^^^^
>    |
> note: the lint level is defined here
>   --> cargo-geiger/tests/integration_tests.rs:2:11
>    |
>  2 | #![forbid(warnings)]
>    |           ^^^^^^^^
>    = note: `#[forbid(unused_imports)]` implied by `#[forbid(warnings)]`
>
> error: could not compile `cargo-geiger` (test "integration_tests") due to 1 previous error
```

Encountered in nixpkgs, which currently uses Rust 1.92.0 as the default Rust version.