### PR TITLE
Bump crossbeam-channel to 0.5.16 in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Fixes #564.