### PR TITLE
fix(geiger): leave unsafe scope for fns with unsafe attributes

### DIFF
--- a/geiger/src/find.rs
+++ b/geiger/src/find.rs
@@ -195,6 +195,34 @@ mod tests {
     }
 
     #[test]
+    fn counters_functions_with_unsafe_attributes_do_not_leak_scope() {
+        let expected = RsFileMetrics {
+            counters: CounterBlock {
+                functions: Count {
+                    safe: 2,
+                    unsafe_: 2,
+                },
+                exprs: Count {
+                    safe: 2,
+                    unsafe_: 2,
+                },
+                ..DEFAULT_COUNTERS
+            },
+            ..DEFAULT_METRICS
+        };
+        let file = "
+            #[no_mangle]
+            pub fn f() { f(); }
+            pub fn f() { f(); }
+            #[export_name = \"exported_f\"]
+            pub fn f() { f(); }
+            pub fn f() { f(); }
+        ";
+        let actual = find_unsafe_in_string(file, IncludeTests::No).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn counters_exprs() {
         let file = "
             pub fn f() {

--- a/geiger/src/geiger_syn_visitor.rs
+++ b/geiger/src/geiger_syn_visitor.rs
@@ -60,7 +60,7 @@ impl<'ast> visit::Visit<'ast> for GeigerSynVisitor {
         }
         self.metrics.counters.functions.count(unsafe_fn);
         visit::visit_item_fn(self, item_fn);
-        if item_fn.sig.unsafety.is_some() {
+        if unsafe_fn {
             self.exit_unsafe_scope()
         }
     }


### PR DESCRIPTION
`visit_item_fn` enters an unsafe scope when a function is `unsafe fn` or carries `#[no_mangle]` / `#[export_name]`, but only leaves that scope again for `unsafe fn`. A function marked only by attribute therefore increments `unsafe_scopes` without ever decrementing it, and every expression visited afterwards in the same file is counted as unsafe.

Leave the scope on the same condition used to enter it.