### PR TITLE
fix(geiger): detect edition 2024 unsafe attributes

### DIFF
--- a/geiger/src/find.rs
+++ b/geiger/src/find.rs
@@ -267,4 +267,33 @@ mod tests {
         let actual = find_unsafe_in_string(file, IncludeTests::Yes).unwrap();
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn counters_functions_with_edition_2024_unsafe_attributes() {
+        let expected = RsFileMetrics {
+            counters: CounterBlock {
+                functions: Count {
+                    safe: 1,
+                    unsafe_: 3,
+                },
+                exprs: Count {
+                    safe: 1,
+                    unsafe_: 3,
+                },
+                ..DEFAULT_COUNTERS
+            },
+            ..DEFAULT_METRICS
+        };
+        let file = "
+            pub fn f() { f(); }
+            #[unsafe(no_mangle)]
+            pub fn f() { f(); }
+            #[unsafe(export_name = \"exported_f\")]
+            pub fn f() { f(); }
+            #[unsafe(naked)]
+            pub extern \"C\" fn f() { f(); }
+        ";
+        let actual = find_unsafe_in_string(file, IncludeTests::No).unwrap();
+        assert_eq!(actual, expected);
+    }
 }

--- a/geiger/src/lib.rs
+++ b/geiger/src/lib.rs
@@ -85,6 +85,12 @@ fn is_test_fn(item_fn: &ItemFn) -> bool {
 
 fn has_unsafe_attributes(item_fn: &ItemFn) -> bool {
     item_fn.attrs.iter().any(|attr| {
+        // Since edition 2024 these attributes have to be wrapped, as in
+        // `#[unsafe(no_mangle)]`. The wrapper is only permitted on
+        // attributes that are unsafe to apply, so its presence is enough.
+        if attr.path().is_ident("unsafe") {
+            return true;
+        }
         if attr.path().is_ident("no_mangle") {
             return true;
         }


### PR DESCRIPTION
`has_unsafe_attributes` matches `#[no_mangle]` and `#[export_name]` by attribute path. Edition 2024 requires both to be written wrapped, as `#[unsafe(no_mangle)]` and `#[unsafe(export_name = ...)]`. Those parse with `unsafe` as the attribute path, so neither matches. The functions carrying them are counted as safe.

Match the `unsafe` path as well. The wrapper is only permitted on attributes that are unsafe to apply, so this also covers `#[unsafe(naked)]` and `#[unsafe(link_section)]`.