### PR TITLE
fix(cargo-geiger): remove unused import in integration tests

### DIFF
--- a/cargo-geiger/tests/integration_tests.rs
+++ b/cargo-geiger/tests/integration_tests.rs
@@ -8,7 +8,6 @@ use self::run::run_geiger_with;
 
 use insta::assert_snapshot;
 use rstest::rstest;
-use std::env;
 use std::process::Output;
 
 #[rstest(


### PR DESCRIPTION
`integration_tests.rs` imports `std::env` without using it. The `context` module, which is the only place that reads an environment variable, has its own import. Under the crate-level `forbid(warnings)` the redundant import fails the build of the test target on current stable.